### PR TITLE
Add Insert note feature

### DIFF
--- a/src/ZoteroItem.ts
+++ b/src/ZoteroItem.ts
@@ -14,10 +14,14 @@ export class ZoteroItem {
 
     raw: ZoteroRawItem;
     linkTemplate: string;
+    noteTitleTemplate: string;
+    noteContentTemplate: string;
 
-    constructor(raw: ZoteroRawItem, { linkTemplate }: Partial<ZoteroPluginSettings>) {
+    constructor(raw: ZoteroRawItem, { linkTemplate, noteTitleTemplate, noteContentTemplate, noteDirectory }: Partial<ZoteroPluginSettings>) {
         this.raw = raw;
         this.linkTemplate = linkTemplate;
+        this.noteTitleTemplate = noteTitleTemplate;
+        this.noteContentTemplate = noteContentTemplate;
     }
 
     getKey() {
@@ -102,4 +106,13 @@ export class ZoteroItem {
     getLink() {
         return `[${renderString(this.linkTemplate, this.getValues())}](zotero://select/library/items/${this.getKey()})`;
     }
+
+    getNoteTitle() {
+        return renderString(this.noteTitleTemplate, this.getValues()).replace(/[*"\\/<>:|?]/g, '_');
+    }
+
+    getNoteContent() {
+        return renderString(this.noteContentTemplate, this.getValues());
+    }
+    
 }

--- a/src/ZoteroPlugin.ts
+++ b/src/ZoteroPlugin.ts
@@ -1,6 +1,7 @@
 import { Editor, Plugin } from 'obsidian';
 import { ZoteroConnector } from './ZoteroConnector';
-import { ZoteroSearchModal } from './ZoteroSearchModal';
+import { ZoteroSearchModalLink } from './ZoteroSearchModalLink';
+import { ZoteroSearchModalNote } from './ZoteroSearchModalNote';
 import { ZoteroSettingTab } from "./ZoteroSettingTab";
 import { DEFAULT_SETTINGS, ZoteroPluginSettings } from './ZoteroPluginSettings';
 
@@ -18,7 +19,15 @@ export class ZoteroPlugin extends Plugin {
             id: 'zotero-insert-link',
             name: 'Insert link',
             editorCallback: (editor: Editor) => {
-                new ZoteroSearchModal(this.app, this.zoteroConnector, editor).open();
+                new ZoteroSearchModalLink(this.app, this.zoteroConnector, editor, this.settings).open();
+            }
+        });
+
+        this.addCommand({
+            id: 'zotero-insert-note',
+            name: 'Insert note',
+            editorCallback: (editor: Editor) => {
+                new ZoteroSearchModalNote(this.app, this.zoteroConnector, editor, this.settings).open();
             }
         });
 

--- a/src/ZoteroPluginSettings.ts
+++ b/src/ZoteroPluginSettings.ts
@@ -2,10 +2,16 @@ export interface ZoteroPluginSettings {
     host: string;
     port: string;
     linkTemplate: string;
+    noteDirectory: string;
+    noteTitleTemplate: string;
+    noteContentTemplate: string;
 }
 
 export const DEFAULT_SETTINGS: Partial<ZoteroPluginSettings> = {
     host: 'localhost',
     port: '23119',
     linkTemplate: '{{ title }}',
+    noteDirectory: 'Reading notes',
+    noteTitleTemplate: '{{ firstAuthor.lastName }}{% if authors | length == 2 %} and {{ (authors | last).lastName }}{% elif authors | length > 2 %}et al.{% endif %} {{ date.year }} {{ title }}',
+    noteContentTemplate: "[Open in Zotero](zotero://select/library/items/{{ key }})\n"
 };

--- a/src/ZoteroSearchModal.ts
+++ b/src/ZoteroSearchModal.ts
@@ -2,16 +2,19 @@
 import { App, Editor, SuggestModal } from 'obsidian';
 import { ZoteroConnector } from './ZoteroConnector';
 import { ZoteroItem } from './ZoteroItem';
+import { ZoteroPluginSettings } from './ZoteroPluginSettings';
 
-export class ZoteroSearchModal extends SuggestModal<ZoteroItem> {
+export abstract class ZoteroSearchModal extends SuggestModal<ZoteroItem> {
 
     connector: ZoteroConnector;
     editor: Editor;
+    settings: ZoteroPluginSettings;
 
-    constructor(app: App, connector: ZoteroConnector, editor: Editor) {
+    constructor(app: App, connector: ZoteroConnector, editor: Editor, settings: ZoteroPluginSettings) {
         super(app);
         this.connector = connector;
         this.editor = editor;
+        this.settings = settings;
     }
 
     getSuggestions(query: string): Promise<ZoteroItem[]> {
@@ -23,7 +26,4 @@ export class ZoteroSearchModal extends SuggestModal<ZoteroItem> {
         el.createEl('small', { text: item.getKey() });
     }
 
-    onChooseSuggestion(item: ZoteroItem) {
-        this.editor.replaceRange(item.getLink(), this.editor.getCursor());
-    }
 }

--- a/src/ZoteroSearchModalLink.ts
+++ b/src/ZoteroSearchModalLink.ts
@@ -1,0 +1,10 @@
+
+import { ZoteroSearchModal } from './ZoteroSearchModal';
+import { ZoteroItem } from './ZoteroItem';
+
+export class ZoteroSearchModalLink extends ZoteroSearchModal {
+
+    onChooseSuggestion(item: ZoteroItem) {
+        this.editor.replaceRange(item.getLink(), this.editor.getCursor());
+    }
+}

--- a/src/ZoteroSearchModalNote.ts
+++ b/src/ZoteroSearchModalNote.ts
@@ -1,0 +1,48 @@
+
+import { normalizePath, TFile } from 'obsidian';
+import { ZoteroSearchModal } from './ZoteroSearchModal';
+import { ZoteroItem } from './ZoteroItem';
+import { join } from 'path';
+
+export class ZoteroSearchModalNote extends ZoteroSearchModal {
+
+    async findOrCreateNoteFor(item: ZoteroItem): Promise<TFile> {
+        const path = join(this.settings.noteDirectory, `${item.getNoteTitle()}.md`);
+        const normalizedPath = normalizePath(path);
+        let file = this.app.vault.getAbstractFileByPath(normalizedPath);
+        if (!file) {
+            const matches = this.app.vault
+                .getMarkdownFiles()
+                .filter((f) => f.path.toLowerCase() == normalizedPath.toLowerCase());
+            if (matches.length > 0) {
+                // note exists
+                file = matches[0];
+            } else {
+                // create new note
+                try {
+                    const directory = normalizePath(this.settings.noteDirectory);
+                    const directoryExists = await this.app.vault.adapter.exists(directory);
+                    if (!directoryExists) {
+                        await this.app.vault.createFolder(directory);
+                    }
+                    file = await this.app.vault.create(
+                        path,
+                        item.getNoteContent(),
+                    );
+                } catch (exc) {
+                    console.log('Could not create Zotero note');
+                    throw exc;
+                }
+            }
+        }
+        return file as TFile;
+    }
+
+    onChooseSuggestion(item: ZoteroItem) {
+        this.findOrCreateNoteFor(item)
+            .then((file: TFile) => {
+                this.app.workspace.getLeaf().openFile(file);
+            })
+            .catch(console.error);
+    }
+}

--- a/src/ZoteroSettingTab.ts
+++ b/src/ZoteroSettingTab.ts
@@ -13,27 +13,13 @@ export class ZoteroSettingTab extends PluginSettingTab {
         this.containerEl.empty();
 
         const description = document.createDocumentFragment();
-
         description.append(
             description.createEl('a', {
                 href: 'https://mozilla.github.io/nunjucks/templating.html#builtin-filters',
                 text: 'Nunjucks',
             }),
-            ' syntax is supported.',
+            ' syntax is supported. ',
         );
-
-        new Setting(this.containerEl)
-            .setName('Link title template')
-            .setDesc(description)
-            .addText((text) => text.setPlaceholder('default: {{ title }}')
-                .setValue(this.plugin.settings.linkTemplate)
-                .onChange(async (value) => {
-                    await this.plugin.saveSettings({
-                        linkTemplate: value
-                    });
-                }));
-
-
 
         const availableKeywords = document.createDocumentFragment();
         const keywordList = availableKeywords.createEl('ul');
@@ -48,10 +34,62 @@ export class ZoteroSettingTab extends PluginSettingTab {
         keywordList.appendChild(availableKeywords.createEl('li', { text: '{% for author in authors %}{{ author.lastName}}, {{ author.firstName | first }}., {% endfor %}'}));
 
         availableKeywords.append(
-            'Following keywords are available:',
+            'The following keywords are available:',
             keywordList
         );
 
-        new Setting(this.containerEl).setDesc(availableKeywords);
+        description.append(availableKeywords);
+
+        new Setting(this.containerEl).setDesc(description);
+
+
+        // links
+        this.containerEl.createEl('h4', { text: 'Link settings' });
+
+        new Setting(this.containerEl)
+            .setName('Link title template')
+            .addText((text) => text.setPlaceholder('default: {{ title }}')
+                .setValue(this.plugin.settings.linkTemplate)
+                .onChange(async (value) => {
+                    await this.plugin.saveSettings({
+                        linkTemplate: value
+                    });
+                }));
+
+        // note
+        this.containerEl.createEl('h4', { text: 'Note settings' });
+
+        new Setting(this.containerEl)
+            .setName('Note directory')
+            .addText((text) => text
+                    .setValue(this.plugin.settings.noteDirectory)
+                    .onChange(async (value) => {
+                    await this.plugin.saveSettings({
+                        noteDirectory: value
+                    });
+                }))
+            .setDesc(
+                'Save note file in this directory within the vault. If empty, notes will be stored in the root directory of the vault.',
+            );
+
+        new Setting(this.containerEl)
+            .setName('Note title template')
+            .addText((text) => text
+                    .setValue(this.plugin.settings.noteTitleTemplate)
+                    .onChange(async (value) => {
+                    await this.plugin.saveSettings({
+                        noteTitleTemplate: value
+                    });
+                }));
+
+        new Setting(this.containerEl)
+            .setName('Note content template')
+            .addTextArea((text) => text
+                    .setValue(this.plugin.settings.noteContentTemplate)
+                    .onChange(async (value) => {
+                    await this.plugin.saveSettings({
+                        noteContentTemplate: value
+                    });
+                }));
     }
 }


### PR DESCRIPTION
Thanks a lot for your plugin, it's great! 

In my vault, I like to put the Zotero links into their own file so it's easy to reference notes related to the literature from there. 

I've extended the plugin to do this note creation from a template automatically via an "Zotero: Insert note" command similar to the existing "Zotero: Insert Link" command. 

If you are interested in adding such a feature, here is an initial implementation.