### PR TITLE
Add search APIs: search by TitleCreatorYear or search by Tag

### DIFF
--- a/src/ZoteroAdapter.ts
+++ b/src/ZoteroAdapter.ts
@@ -21,6 +21,22 @@ export class ZoteroAdapter {
         }])
     }
 
+    public searchTitleCreatorYear(query: string) {
+        return this.search([{
+            condition: 'quicksearch-titleCreatorYear',
+            value: query
+        }])
+    }
+
+    public searchTag(query: string) {
+        return this.search([{
+            condition: 'tag',
+            operator: "is",
+            value: query,
+            required: true
+        }])
+    }
+
     public search(conditions: any[]) {
         return request({
             url: `${this.baseUrl}/search`,

--- a/src/ZoteroSuggestModalTag.ts
+++ b/src/ZoteroSuggestModalTag.ts
@@ -1,0 +1,38 @@
+import { App, SuggestModal } from 'obsidian';
+import { ZoteroAdapter } from './ZoteroAdapter';
+import { ZoteroItem } from './ZoteroItem';
+
+export class ZoteroSuggestModalTag extends SuggestModal<ZoteroItem> {
+
+    adapter: ZoteroAdapter;
+    onSelect: any;
+
+    constructor(app: App, adapter: ZoteroAdapter, onSelect: any) {
+        super(app);
+        this.adapter = adapter;
+        this.onSelect = onSelect;
+    }
+
+    getSuggestions(query: string): Promise<ZoteroItem[]> {
+        return this.adapter.searchTag(query);
+    }
+
+    renderSuggestion(item: ZoteroItem, el: HTMLElement) {
+        el.createEl('div', { text: item.getTitle() });
+        el.createEl('small', { text: item.getKey() });
+    }
+
+    onChooseSuggestion(item: ZoteroItem) {
+        this.onSelect(item);
+    }
+}
+
+export function promisedZoteroSuggestModalTag(...args: [App, ZoteroAdapter]): Promise<ZoteroItem> {
+    return new Promise((resolve, reject) => {
+        try {
+            new ZoteroSuggestModalTag(...args, (item: ZoteroItem) => resolve(item)).open();
+        } catch (e) {
+            reject(e);
+        }
+    });
+}

--- a/src/ZoteroSuggestModalTitleCreatorYear.ts
+++ b/src/ZoteroSuggestModalTitleCreatorYear.ts
@@ -1,0 +1,38 @@
+import { App, SuggestModal } from 'obsidian';
+import { ZoteroAdapter } from './ZoteroAdapter';
+import { ZoteroItem } from './ZoteroItem';
+
+export class ZoteroSuggestModal extends SuggestModal<ZoteroItem> {
+
+    adapter: ZoteroAdapter;
+    onSelect: any;
+
+    constructor(app: App, adapter: ZoteroAdapter, onSelect: any) {
+        super(app);
+        this.adapter = adapter;
+        this.onSelect = onSelect;
+    }
+
+    getSuggestions(query: string): Promise<ZoteroItem[]> {
+        return this.adapter.searchTitleCreatorYear(query);
+    }
+
+    renderSuggestion(item: ZoteroItem, el: HTMLElement) {
+        el.createEl('div', { text: item.getTitle() });
+        el.createEl('small', { text: item.getKey() });
+    }
+
+    onChooseSuggestion(item: ZoteroItem) {
+        this.onSelect(item);
+    }
+}
+
+export function promisedZoteroSuggestModalTitleCreatorYear(...args: [App, ZoteroAdapter]): Promise<ZoteroItem> {
+    return new Promise((resolve, reject) => {
+        try {
+            new promisedZoteroSuggestModalTitleCreatorYear(...args, (item: ZoteroItem) => resolve(item)).open();
+        } catch (e) {
+            reject(e);
+        }
+    });
+}

--- a/src/plugin-api/ZoteroBridgeApiV1.ts
+++ b/src/plugin-api/ZoteroBridgeApiV1.ts
@@ -13,4 +13,11 @@ export class ZoteroBridgeApiV1 {
         return promisedZoteroSuggestModal(this.plugin.app, this.plugin.zoteroAdapter);
     }
 
+    searchTitleCreatorYear() {
+        return promisedZoteroSuggestModalTitleCreatorYear(this.plugin.app, this.plugin.zoteroAdapter);
+    }
+
+    searchTag() {
+        return promisedZoteroSuggestModalTag(this.plugin.app, this.plugin.zoteroAdapter);
+    }
 }


### PR DESCRIPTION
I'm a user of [Zotero-Link](https://github.com/vanakat/zotero-link) Plugin. I encountered [Search Accuracy Issue](https://github.com/vanakat/zotero-link/issues/2) and I tried the solution proposed by [this comment](https://github.com/vanakat/zotero-link/issues/2#issuecomment-1405605311), which solved my problem.

Zotero-Bridge‘s original search API uses "quicksearch-everything" search mode provided by [ZotServer](https://github.com/MunGell/ZotServer) Search Endpoint. In this Pull Request, I added to two more search APIs that uses "quicksearch-titleCreatorYear" and "tag"  search modes of [ZotServer](https://github.com/MunGell/ZotServer), respectively. These new APIs can be used by [Zotero-Link](https://github.com/vanakat/zotero-link) to provide different search modes.