### PR TITLE
Default to title instead of shortTitle

### DIFF
--- a/src/ZoteroItem.ts
+++ b/src/ZoteroItem.ts
@@ -23,7 +23,11 @@ export class ZoteroItem {
     }
 
     getTitle() {
-        return this.raw.shortTitle || this.raw.title || this.getNoteExcerpt() || '[No Title]';
+        return this.raw.title || this.raw.shortTitle || this.getNoteExcerpt() || '[No Title]';
+    }
+
+    getShortTitle() {
+        return this raw.shortTitle;
     }
 
     getAuthors() {


### PR DESCRIPTION
Currently zotero-bridge uses the shortTitle by default instead of the title. This can lead to confusion (see [zotero-link#9](https://github.com/vanakat/zotero-link/issues/9)), and does not allow the full title to be recovered when a short-title exists. This PR changes the `getTitle()` method to default to the title, and fall back to the short-title if it's not present. It also adds another method for the short-title specifically.