### PR TITLE
Improve data parsing + use creatorSummary

### DIFF
--- a/src/ZoteroAdapter.ts
+++ b/src/ZoteroAdapter.ts
@@ -63,7 +63,7 @@ export class LocalAPIV3Adapter implements ZoteroAdapter {
             contentType: 'application/json'
         })
             .then(JSON.parse)
-            .then((items: any[]) => items.filter(item => !['attachment', 'note'].includes(item.data.itemType)).map(item => new ZoteroItem(item.data)))
+            .then((items: any[]) => items.filter(item => !['attachment', 'note'].includes(item.data.itemType)).map(item => new ZoteroItem(item)))
             .catch(() => {
                 new Notice(`Couldn't connect to Zotero, please check the app is open and Zotero Local API is enabled`);
                 return [];

--- a/src/ZoteroItem.ts
+++ b/src/ZoteroItem.ts
@@ -1,12 +1,18 @@
 import { sanitizeHTMLToDom } from 'obsidian';
 
 export interface ZoteroRawItem {
-    key: string;
-    title?: string;
-    shortTitle?: string;
-    creators?: any[];
-    date?: string;
-    note?: string;
+    meta: {
+        creatorSummary?: string;
+        parsedDate?: string;
+    };
+    data: {
+        key: string;
+        title?: string;
+        shortTitle?: string;
+        creators?: any[];
+        date?: string;
+        note?: string;
+    }
 }
 
 /** @public */
@@ -19,15 +25,19 @@ export class ZoteroItem {
     }
 
     getKey() {
-        return this.raw.key;
+        return this.raw.data.key;
     }
 
     getTitle() {
-        return this.raw.title || this.raw.shortTitle || this.getNoteExcerpt() || '[No Title]';
+        return this.raw.data.title || this.raw.data.shortTitle || this.getNoteExcerpt() || '[No Title]';
     }
 
     getShortTitle() {
-        return this.raw.shortTitle;
+        return this.raw.data.shortTitle;
+    }
+
+    getCreatorSummary() {
+        return this.raw.meta.creatorSummary;
     }
 
     getAuthors() {
@@ -41,17 +51,18 @@ export class ZoteroItem {
     }
 
     getCreators() {
-        return this.raw.creators || [];
+        return this.raw.data.creators || [];
     }
 
     getDate() {
-        return this.raw.date ? this.formatDate(this.raw.date) : { year: null, month: null, day: null };
+        const date = this.raw.meta.parsedDate || this.raw.data.date;
+        return date ? this.formatDate(date) : { year: null, month: null, day: null };
     }
 
     getNoteExcerpt() {
-        if (this.raw.note) {
+        if (this.raw.data.note) {
             const div = document.createElement('div');
-            div.appendChild(sanitizeHTMLToDom(this.raw.note));
+            div.appendChild(sanitizeHTMLToDom(this.raw.data.note));
             return (div.textContent || div.innerText || '').trim().substring(0, 50) + '...';
         }
 
@@ -87,9 +98,9 @@ export class ZoteroItem {
         }
 
         return {
-            year: dateObject.getFullYear(),
-            month: dateObject.getMonth() + 1,
-            day: dateObject.getDate()
+            year: dateObject.getUTCFullYear(),
+            month: dateObject.getUTCMonth() + 1,
+            day: dateObject.getUTCDate()
         }
     }
 
@@ -101,6 +112,7 @@ export class ZoteroItem {
             date: this.getDate(),
             authors: this.getAuthors(),
             firstAuthor: this.getAuthor(),
+            creatorSummary: this.getCreatorSummary(),
         };
     }
 }

--- a/src/ZoteroSuggestModal.ts
+++ b/src/ZoteroSuggestModal.ts
@@ -18,24 +18,20 @@ export class ZoteroSuggestModal extends SuggestModal<ZoteroItem> {
     }
 
     renderSuggestion(item: ZoteroItem, el: HTMLElement) {
-        const authors = item.getAuthors();
+        const creator = item.getCreatorSummary();
         el.createEl('div', { text: item.getTitle() });
 
         // author
-        if (authors.length > 0) {
-            let text = authors[0].fullName + ' ';
-            if (authors.length > 1) {
-                text += 'et al. '
-            }
-            el.createEl('small', { text });
-
-            // date
-            if (item.getDate()) {
-                el.createEl('small', { text: `(${item.getDate().year}) ` });
-            }
+        if (creator) {
+            el.createEl('small', { text: creator });
         }
 
-        el.createEl('small', { text: `[${item.getKey()}]`, cls: 'zotero-bridge__text-secondary' });
+        // date
+        if (item.getDate()) {
+            el.createEl('small', { text: ` (${item.getDate().year})` });
+        }
+
+        el.createEl('small', { text: ` [${item.getKey()}]`, cls: 'zotero-bridge__text-secondary' });
     }
 
     onChooseSuggestion(item: ZoteroItem) {


### PR DESCRIPTION
Uses the parsedData field provided by Zotero as well as the creatorSummary name. The creatorSummary is quite helpful as it uses editors in case no authors are listed and also concats two authors/editors with 'and' and abbreviates more than two with 'et al'. 

Could only test this on Zotero 7 for now. 

closes #14 