### PR TITLE
fix: add Zotero-Allowed-Request header for Zotero 9 local API

### DIFF
--- a/src/ZoteroAdapter.ts
+++ b/src/ZoteroAdapter.ts
@@ -50,7 +50,8 @@ export class LocalAPIV3Adapter implements ZoteroAdapter {
         return request({
             url: `http://${this.settings.host}:${this.settings.port}/api/users/0/groups`,
             method: 'get',
-            contentType: 'application/json'
+            contentType: 'application/json',
+            headers: { "Zotero-Allowed-Request": "true" }
         })
             .then(JSON.parse)
             .then((groups: any[]) => groups.map(group => group.data));
@@ -60,7 +61,8 @@ export class LocalAPIV3Adapter implements ZoteroAdapter {
         return request({
             url: `${this.baseUrl}/items?` + new URLSearchParams(parameters).toString(),
             method: 'get',
-            contentType: 'application/json'
+            contentType: 'application/json',
+            headers: { "Zotero-Allowed-Request": "true" }
         })
             .then(JSON.parse)
             .then((items: any[]) => items.filter(item => !['attachment', 'note'].includes(item.data.itemType)).map(item => new ZoteroItem(item)))


### PR DESCRIPTION
# Fix: Cannot connect to Zotero 9 local API (Zotero-Allowed-Request header)

> [!WARNING]
> I have **no** knowledge of the Zotero API and Obsidian Electron setup. I asked an agent to diagnose and explain to me the situation, then I wrote this PR to fix the thing. But, someone that actually understands the Zotero API and the Obsidian/Electron setup should review this. I also made the agent searched information so I can bootstrap your understanding, hopefully.

## Problem

Running Zotero 9 got me a "Couldn't connect to Zotero". Before v9 it was not there and I changed nothing to my Obsidian, so I suspected the plugin.

## Root cause

> [!NOTE]
> AI generated diagnosis and I manually remove/edit most of the content in order to get you read minimal amount of slop.

Any request whose `User-Agent` starts with `Mozilla/` is treated as a browser request and silently cancelled. Because Obsidian runs on **Electron** (which embeds Chromium), its default `User-Agent` is `Mozilla/5.0 ...`, indistinguishable from a real browser to Zotero's check. [Related Zotero source code](https://github.com/zotero/zotero/blob/431e1dabded4153d2b6d30b0b6c9f53e647c197c/chrome/content/zotero/xpcom/server/server.js#L402-L420)

The security intent is sound: a malicious webpage cannot freely make `fetch()` calls to `http://localhost:23119` and exfiltrate the user's library, because browsers attach an `Origin` header and cannot forge arbitrary request headers cross-origin (CORS blocks it). The `Zotero-Allowed-Request` header therefore acts as a **lightweight CSRF token for the local API**.

## Fix

Add the header.

## References (_did not read_)

- [zotero-dev mailing list: "403 on local API with 'Allow other applications…' enabled"](https://groups.google.com/g/zotero-dev/c/5KM1QVUOeck) — Dan Stillman (Zotero lead) confirms the header and its origin as a DNS rebinding mitigation
- [Zotero Forums: "HTTP user agents that don't identify fail for Zotero >= v5.0.71"](https://forums.zotero.org/discussion/78502/http-user-agents-that-dont-identify-fail-for-zotero-v5-0-71) — introduction of the mechanism
- [zotero-dev beta thread: Electron app developer encountering the same issue](https://groups.google.com/g/zotero-dev/c/ElvHhIFAXrY/m/fA7SKKwsAgAJ)
