### PR TITLE
Fix Zotero Local API requests from Obsidian

### DIFF
--- a/src/ZoteroAdapter.ts
+++ b/src/ZoteroAdapter.ts
@@ -1,4 +1,5 @@
 import { request, Notice } from 'obsidian';
+import * as http from 'http';
 import { ZoteroBridgeSettings } from './ZoteroBridgeSettings';
 import { ZoteroItem } from './ZoteroItem';
 import { ZoteroBridgeConnectionType } from './ZoteroBridgeSettings'
@@ -11,6 +12,43 @@ type ZoteroItemsRequestParameters = {
     since?: string,
     sort?: string,
     q?: string
+}
+
+function localApiRequest(url: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const req = http.get(url, {
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'ZoteroBridge/1.6.6',
+            },
+        }, response => {
+            let body = '';
+
+            response.setEncoding('utf8');
+            response.on('data', chunk => body += chunk);
+            response.on('end', () => {
+                if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+                    reject(new Error(`Zotero Local API returned HTTP ${response.statusCode}: ${body}`));
+                    return;
+                }
+
+                resolve(body);
+            });
+        });
+
+        req.on('error', reject);
+        req.setTimeout(5000, () => {
+            req.destroy(new Error('Zotero Local API request timed out'));
+        });
+    });
+}
+
+function localApiRequestWithFallback(url: string): Promise<string> {
+    return request({
+        url,
+        method: 'get',
+        contentType: 'application/json'
+    }).catch(() => localApiRequest(url));
 }
 
 /**
@@ -47,21 +85,13 @@ export class LocalAPIV3Adapter implements ZoteroAdapter {
     }
 
     groups(): Promise<any[]> {
-        return request({
-            url: `http://${this.settings.host}:${this.settings.port}/api/users/0/groups`,
-            method: 'get',
-            contentType: 'application/json'
-        })
+        return localApiRequestWithFallback(`http://${this.settings.host}:${this.settings.port}/api/users/0/groups`)
             .then(JSON.parse)
             .then((groups: any[]) => groups.map(group => group.data));
     }
 
     items(parameters: ZoteroItemsRequestParameters): Promise<ZoteroItem[]> {
-        return request({
-            url: `${this.baseUrl}/items?` + new URLSearchParams(parameters).toString(),
-            method: 'get',
-            contentType: 'application/json'
-        })
+        return localApiRequestWithFallback(`${this.baseUrl}/items?` + new URLSearchParams(parameters).toString())
             .then(JSON.parse)
             .then((items: any[]) => items.filter(item => !['attachment', 'note'].includes(item.data.itemType)).map(item => new ZoteroItem(item)))
             .catch(() => {

--- a/src/ZoteroBridge.ts
+++ b/src/ZoteroBridge.ts
@@ -22,6 +22,7 @@ export class ZoteroBridge extends Plugin {
 
     async saveSettings(newSettings: Partial<ZoteroBridgeSettings>) {
         Object.assign(this.settings, newSettings);
+        this.zoteroAdapter = new ZoteroAdapters[this.settings.connectionType](this.settings);
         await this.saveData(this.settings);
     }
 }


### PR DESCRIPTION
## Summary

Add a desktop-local fallback for Zotero 7+ Local API requests when Obsidian's browser-like `request()` path fails.

This keeps the current request path as the first attempt, so Zotero versions/environments where the existing Obsidian request works continue to behave the same. If that request fails, Zotero Bridge retries through Node's local `http` module.

## Root cause / motivation

I reproduced a failure with Obsidian 1.12.7 and Zotero 9.0.3 where Local API requests made from Obsidian fail with `net::ERR_EMPTY_RESPONSE`, while the same endpoint works via a direct local request.

The failure can be reproduced locally by adding a browser-style origin header:

```sh
curl -H 'Origin: app://obsidian.md' \
  'http://127.0.0.1:23119/api/users/0/items?limit=1'
# curl: (52) Empty reply from server
```

Zotero forum guidance also says the local API is intended for direct local application requests rather than browser access. Since this behavior may vary by Zotero version and platform, this PR uses a fallback rather than replacing the existing Obsidian request path unconditionally.

## Changes

- Try the existing Obsidian `request()` call first for Zotero 7+ Local API reads.
- Fall back to Node's `http.get()` with simple desktop-client headers if that request fails.
- Apply the fallback to `items` and `groups` Local API calls.
- Refresh the active adapter after settings changes so switching connection type/port takes effect without a full Obsidian restart.

## Validation

- `npx tsc -noEmit -skipLibCheck`
- `TZ=UTC npm test -- --runInBand`
- `node esbuild.config.mjs production`

Note: `npm run build` currently reaches the existing API Extractor step and fails because `api-extractor.json` expects `types/main.d.ts`, while the declaration command emits `types/src/main.d.ts`. That appears unrelated to this change.
